### PR TITLE
updated the path for the hero image

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -3,7 +3,7 @@
 
 An open source React.js component library for beautifully shaded canvas, brought to you by **[Latent Cat](https://latentcat.com)**.
 
-![hero](github/hero.webp)
+![hero](/github/hero.webp)
 
 ## Documentation
 


### PR DESCRIPTION
The README file in `/core` was not able to find the hero webp image from `/github` folder.
I had to change the path from `github/hero.webp` to `/github/hero.webp`
