### PR TITLE
fix: add type export

### DIFF
--- a/core/lib/index.ts
+++ b/core/lib/index.ts
@@ -10,3 +10,4 @@ export { Slides } from "./components/slides";
 export { defaultComponents } from "./components/slides/default_components";
 export { sliceMdxString } from "./components/slides/slice";
 export { SlidesActionButton } from "./components/slides/action_button";
+export type { CommonProps, ControlProps, TimeProps } from "./types/CommonProps";


### PR DESCRIPTION
I used `Lumiflex` component, then i found there is no type reference I can do.

## Before

<img width="629" alt="image" src="https://github.com/user-attachments/assets/c411ef49-391b-41f8-ae92-7ed6c48c8cd6">

There is no type in `LumiflexProps`.

<img width="849" alt="스크린샷 2024-10-20 오후 1 38 32" src="https://github.com/user-attachments/assets/abf010f0-913f-40ac-b2f1-c28702e6f0a3">

I found that there is no type about `CommonProps, ControlProps, TimeProps` in index.d.ts where the type entry file.

<img width="656" alt="image" src="https://github.com/user-attachments/assets/06fb5eba-13c6-4da1-a79a-af36352eaf0e">

So I add type export in 

## After

<img width="629" alt="image" src="https://github.com/user-attachments/assets/0ea1040c-1806-4eb3-ae2e-fcab57321239">


